### PR TITLE
Add missing packages for gef

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ ENV KEYSTONEVER 0.9.1
 
 ## Prepare dependencies
 RUN apt-get update -y 
-RUN apt-get install -y python-dev libglib2.0-dev wget less vim sed cmake time python-pip gdb git libssl-dev libffi-dev build-essential
+RUN apt-get install -y python-dev libglib2.0-dev wget less vim sed cmake time python-pip gdb git libssl-dev libffi-dev build-essential python3-pip
 RUN apt-get install -y lib32stdc++-4.8-dev libc6-dev-i386
 RUN pip install --upgrade pip pwntools
 RUN pip3 install --upgrade unicorn ropper capstone retdec-python keystone-engine

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ RUN apt-get update -y
 RUN apt-get install -y python-dev libglib2.0-dev wget less vim sed cmake time python-pip gdb git libssl-dev libffi-dev build-essential
 RUN apt-get install -y lib32stdc++-4.8-dev libc6-dev-i386
 RUN pip install --upgrade pip pwntools
+RUN pip3 install --upgrade unicorn ropper capstone retdec-python keystone-engine
 RUN apt-get clean
 
 ###########################################################
@@ -80,7 +81,7 @@ RUN git clone https://github.com/scwuaptx/Pwngdb.git
 RUN cp ./Pwngdb/.gdbinit ~/
 RUN wget -O ~/.gdbinit-gef.py -q https://github.com/hugsy/gef/raw/master/gef.py
 RUN git clone https://github.com/longld/peda.git ~/peda
-RUN tac ~/.gdbinit > gdbinit.tmp; echo "~/.gdbinit-gef.py\nsource ~/Pwngdb/angelheap/gdbinit.py" >> gdbinit.tmp && tac ./gdbinit.tmp > ~/.gdbinit && rm -f gdbinit.tmp
+RUN tac ~/.gdbinit > gdbinit.tmp; echo "source ~/.gdbinit-gef.py\nsource ~/Pwngdb/angelheap/gdbinit.py" >> gdbinit.tmp && tac ./gdbinit.tmp > ~/.gdbinit && rm -f gdbinit.tmp
 ###########################################################
 # Cleanup
 RUN rm -rf /usr/src/*


### PR DESCRIPTION
```
[*] Command `unicorn-emulate` is missing, reason  →  Missing `unicorn` package for Python3. Install with `pip3 install unicorn`.
[*] Command `ropper` is missing, reason  →  Missing `ropper` package for Python3, install with: `pip3 install ropper`.
[*] Command `capstone-disassemble` is missing, reason  →  Missing `capstone` package for Python3. Install with `pip3 install capstone`.
[*] Command `retdec` is missing, reason  →  Missing `retdec-python` package for Python3, install with: `pip3 install retdec-python`.
[*] Command `set-permission` is missing, reason  →  Missing `keystone-engine` package for Python3, install with: `pip3 install keystone-engine`.
[*] Command `assemble` is missing, reason  →  Missing `keystone-engine` package for Python3, install with: `pip3 install keystone-engine`.
```